### PR TITLE
Add HX-Reswap header to response helper

### DIFF
--- a/src/Htmx/HtmxResponseHeaders.cs
+++ b/src/Htmx/HtmxResponseHeaders.cs
@@ -13,6 +13,7 @@ namespace Htmx
         public static class Keys
         {
             public const string Push = "HX-Push-Url";
+            public const string Location = "HX-Location";
             public const string Redirect = "HX-Redirect";
             public const string Refresh = "HX-Refresh";
             public const string Trigger = "HX-Trigger";
@@ -20,6 +21,7 @@ namespace Htmx
             public const string TriggerAfterSwap = "HX-Trigger-After-Swap";
             public const string Reswap = "HX-Reswap";
             public const string Retarget = "HX-Retarget";
+            public const string ReplaceUrl = "HX-Replace-Url";
         }
 
         internal HtmxResponseHeaders(IHeaderDictionary headers)
@@ -58,6 +60,28 @@ namespace Htmx
         public HtmxResponseHeaders Reswap(string value)
         {
             _headers[Keys.Reswap] = value;
+            return this;
+        }
+        
+        /// <summary>
+        /// Allows you to do a client-side redirect that does not do a full page reload
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public HtmxResponseHeaders Location(string value)
+        {
+            _headers[Keys.Location] = value;
+            return this;
+        }
+        
+        /// <summary>
+        /// Replaces the current URL in the location bar
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public HtmxResponseHeaders ReplaceUrl(string value)
+        {
+            _headers[Keys.ReplaceUrl] = value;
             return this;
         }
 

--- a/src/Htmx/HtmxResponseHeaders.cs
+++ b/src/Htmx/HtmxResponseHeaders.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Http;
 
 namespace Htmx

--- a/src/Htmx/HtmxResponseHeaders.cs
+++ b/src/Htmx/HtmxResponseHeaders.cs
@@ -12,7 +12,7 @@ namespace Htmx
 
         public static class Keys
         {
-            public const string Push = "HX-Push-Url";
+            public const string PushUrl = "HX-Push-Url";
             public const string Location = "HX-Location";
             public const string Redirect = "HX-Redirect";
             public const string Refresh = "HX-Refresh";
@@ -34,9 +34,20 @@ namespace Htmx
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        [Obsolete("HX-Push was replaced with HX-Push-Url, use PushUrl(value) instead")]
         public HtmxResponseHeaders Push(string value)
         {
-            _headers[Keys.Push] = value;
+            return PushUrl(value);
+        }
+
+        /// <summary>
+        ///	pushes a new url into the history stack
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public HtmxResponseHeaders PushUrl(string value)
+        {
+            _headers[Keys.PushUrl] = value;
             return this;
         }
 

--- a/src/Htmx/HtmxResponseHeaders.cs
+++ b/src/Htmx/HtmxResponseHeaders.cs
@@ -12,12 +12,13 @@ namespace Htmx
 
         public static class Keys
         {
-            public const string Push = "HX-Push";
+            public const string Push = "HX-Push-Url";
             public const string Redirect = "HX-Redirect";
             public const string Refresh = "HX-Refresh";
             public const string Trigger = "HX-Trigger";
             public const string TriggerAfterSettle = "HX-Trigger-After-Settle";
             public const string TriggerAfterSwap = "HX-Trigger-After-Swap";
+            public const string Reswap = "HX-Reswap";
             public const string Retarget = "HX-Retarget";
         }
 
@@ -45,6 +46,18 @@ namespace Htmx
         public HtmxResponseHeaders Redirect(string value)
         {
             _headers[Keys.Redirect] = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Allows you to specify how the response will be swapped
+        /// See https://htmx.org/attributes/hx-swap/ for values
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public HtmxResponseHeaders Reswap(string value)
+        {
+            _headers[Keys.Reswap] = value;
             return this;
         }
 


### PR DESCRIPTION
The new `HX-Reswap` header allows users to specify how they want the response content to be handled (useful when returning either a response or an event driven workflow), so added it to the response helper.

Also updated 'Push' to be 'Push-Url'.