### PR TITLE
Better API for Triggers - WithTrigger(event, detail, timing)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/Readme.md
+++ b/Readme.md
@@ -45,13 +45,24 @@ We can set Http Response headers using the `Htmx` extension method, which passes
 
 ```c#
 Response.Htmx(h => {
-    h.Push("/new-url")
-     .TriggerAfterSettle("yes")
-     .TriggerAfterSwap("cool");
+    h.PushUrl("/new-url")
+     .WithTrigger("cool")
 });
 ```
 
 Read more about the HTTP response headers at the [official documentation site](https://htmx.org/reference/#request_headers).
+
+#### Triggering Client-Side Events
+
+You can trigger client side events with HTMX using the `HX-Trigger` header. Htmx.Net provides a `WithTrigger` helper method to configure one or more events that you wish to trigger.
+
+```c#
+Response.Htmx(h => {
+    h.WithTrigger("yes")
+     .WithTrigger("cool", timing: HtmxTriggerTiming.AfterSettle)
+     .WithTrigger("neat", new { valueForFrontEnd: 42, status: "Done!" }, timing: Htmx.TriggerTiming.AfterSwap);
+});
+```
 
 ## Htmx.TagHelpers
 
@@ -169,6 +180,8 @@ A simpler way is to use the `HtmlExtensions` class that extends `IHtmlHelper`.
 ```
 
 This html helper will result in a `<script>` tag along with the previously mentioned JavaScript. **Note: You can still register multiple event handlers for `htmx:configRequest`, so having more than one is ok.**
+
+Note that if the `hx-[get|post|put]` attribute is on a `<form ..>` tag, the ASP.NET Tag Helpers will add the Anti-forgery Token as an `input` element and you do not need to further configure your requests as above. You could also use [`hx-include`](https://htmx.org/attributes/hx-include/) pointing to a form, but this all comes down to a matter of preference.
 
 
 ## License

--- a/src/Htmx/Htmx.csproj
+++ b/src/Htmx/Htmx.csproj
@@ -27,6 +27,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="System.Text.Json" Version="6.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Htmx/HtmxHttpExtensions.cs
+++ b/src/Htmx/HtmxHttpExtensions.cs
@@ -56,7 +56,9 @@ namespace Htmx
         /// <param name="action">Action used to action the response headers</param>
         public static void Htmx(this HttpResponse response, Action<HtmxResponseHeaders> action)
         {
-            action(new HtmxResponseHeaders(response.Headers));
+            var headerContainer = new HtmxResponseHeaders(response.Headers);
+            action(headerContainer);
+            headerContainer.Process();
         }
 
         internal static T GetValueOrDefault<T>(this IHeaderDictionary headers, string key, T @default)

--- a/src/Htmx/HtmxTriggerTiming.cs
+++ b/src/Htmx/HtmxTriggerTiming.cs
@@ -1,0 +1,26 @@
+namespace Htmx
+{
+    /// <summary>
+    /// Defines when a trigger runs
+    /// https://htmx.org/headers/hx-trigger/
+    /// </summary>
+    public enum HtmxTriggerTiming
+    {
+        /// <summary>
+        /// Triggers event as soon as the response is received
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Triggers event after the settling step
+        /// https://htmx.org/docs/#request-operations
+        /// </summary>
+        AfterSettle,
+
+        /// <summary>
+        /// Triggers event after the swap step
+        /// https://htmx.org/docs/#request-operations
+        /// </summary>
+        AfterSwap
+    }
+}

--- a/test/Htmx.Tests/Htmx.Tests.csproj
+++ b/test/Htmx.Tests/Htmx.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/test/Htmx.Tests/HtmxHttpResponseExtensionsTests.cs
+++ b/test/Htmx.Tests/HtmxHttpResponseExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Http;
 using NuGet.Frameworks;
 using Xunit;
@@ -115,6 +116,27 @@ namespace Htmx.Tests
             
             Assert.True(Headers.ContainsKey(Keys.Trigger));
             Assert.Equal(expected, Headers[Keys.Trigger]);
+        }
+
+        [Fact]
+        public void Cant_use_legacy_trigger_and_with_trigger()
+        {
+            Response.Htmx(h => h.Trigger("cool"));
+            Assert.Throws<Exception>(() => Response.Htmx(h => h.WithTrigger("neat")));
+        }
+        
+        [Fact]
+        public void Cant_use_legacy_triggeraftersettle_and_with_trigger()
+        {
+            Response.Htmx(h => h.TriggerAfterSettle("cool"));
+            Assert.Throws<Exception>(() => Response.Htmx(h => h.WithTrigger("neat", timing: HtmxTriggerTiming.AfterSettle)));
+        }
+        
+        [Fact]
+        public void Cant_use_legacy_triggerafterswap_and_with_trigger()
+        {
+            Response.Htmx(h => h.TriggerAfterSwap("cool"));
+            Assert.Throws<Exception>(() => Response.Htmx(h => h.WithTrigger("neat", timing: HtmxTriggerTiming.AfterSwap)));
         }
 
         [Fact]

--- a/test/Htmx.Tests/HtmxHttpResponseExtensionsTests.cs
+++ b/test/Htmx.Tests/HtmxHttpResponseExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NuGet.Frameworks;
 using Xunit;
 using Xunit.Abstractions;
 using static Htmx.HtmxResponseHeaders;
@@ -26,6 +27,92 @@ namespace Htmx.Tests
                 h.Trigger(expected);
             });
 
+            Assert.True(Headers.ContainsKey(Keys.Trigger));
+            Assert.Equal(expected, Headers[Keys.Trigger]);
+        }
+
+        [Fact]
+        public void Can_add_single_trigger()
+        {
+            const string expected = "cool";
+            Response.Htmx(h =>
+            {
+                h.WithTrigger(expected);
+            });
+            
+            Assert.True(Headers.ContainsKey(Keys.Trigger));
+            Assert.Equal(expected, Headers[Keys.Trigger]);
+        }
+
+        [Fact]
+        public void Can_add_single_trigger_at_timings()
+        {
+            const string expected = "cool";
+            Response.Htmx(h =>
+            {
+                h.WithTrigger(expected)
+                    .WithTrigger(expected, timing: HtmxTriggerTiming.AfterSettle)
+                    .WithTrigger(expected, timing: HtmxTriggerTiming.AfterSwap);
+            });
+            
+            Assert.True(Headers.ContainsKey(Keys.Trigger));
+            Assert.True(Headers.ContainsKey(Keys.TriggerAfterSettle));
+            Assert.True(Headers.ContainsKey(Keys.TriggerAfterSwap));
+            Assert.Equal(expected, Headers[Keys.Trigger]);
+            Assert.Equal(expected, Headers[Keys.TriggerAfterSettle]);
+            Assert.Equal(expected, Headers[Keys.TriggerAfterSwap]);
+        }
+        
+        [Fact]
+        public void Can_add_multiple_triggers()
+        {
+            const string expected = @"{""cool"":"""",""neat"":""""}";
+            Response.Htmx(h =>
+            {
+                h.WithTrigger("cool");
+                h.WithTrigger("neat");
+            });
+            
+            Assert.True(Headers.ContainsKey(Keys.Trigger));
+            Assert.Equal(expected, Headers[Keys.Trigger]);
+        }
+
+        [Fact]
+        public void Can_add_single_trigger_with_basic_detail()
+        {
+            const string expected = @"{""cool"":""magic""}";
+            Response.Htmx(h =>
+            {
+                h.WithTrigger("cool", "magic");
+            });
+            
+            Assert.True(Headers.ContainsKey(Keys.Trigger));
+            Assert.Equal(expected, Headers[Keys.Trigger]);
+        }
+        
+        [Fact]
+        public void Can_add_single_trigger_with_detail()
+        {
+            const string expected = @"{""cool"":{""magic"":42}}";
+            Response.Htmx(h =>
+            {
+                h.WithTrigger("cool", new { magic = 42 });
+            });
+            
+            Assert.True(Headers.ContainsKey(Keys.Trigger));
+            Assert.Equal(expected, Headers[Keys.Trigger]);
+        }
+        
+        [Fact]
+        public void Can_add_multiple_triggers_with_detail()
+        {
+            const string expected = @"{""cool"":{""magic"":""something""},""neat"":{""moremagic"":false}}";
+            Response.Htmx(h =>
+            {
+                h.WithTrigger("cool", new { magic = "something" });
+                h.WithTrigger("neat", new { moremagic = false });
+            });
+            
             Assert.True(Headers.ContainsKey(Keys.Trigger));
             Assert.Equal(expected, Headers[Keys.Trigger]);
         }


### PR DESCRIPTION
I didn't expect to do 2 PRs in one day but here it is 🥳 My development team has been using this library with their more recent builds and the biggest grumble they have is what follows, so good work and thank you for building something that is just right for working with HTMX!

The current API for triggers (`.Trigger(value)`) provides the ability to set the header once, meaning that in its most basic form a trigger with no parameters can be specified:
```c#
h.Trigger("event-name");
```

For more control, a manual string would have to be constructed:
```c#
h.Trigger("{\"event-name\":{myVal:42,anotherVal:12}}");
```

For multiple events, the interaction only gets more complex and the user would typically resort to manually constructing JSON or serialising a dictionary:
```c#
h.Trigger("{\"event-name\":{myVal:42,anotherVal:12},\"another-event\":{what:false}}");
```

With that I propose a new API for adding triggers to the response which does the dictionary serialisation method internally, the above details with parameters could now be rewritten as follows:
```c#
h.WithTrigger("event-name", new { myVal = 42, anotherVal = 12 })
   .WithTrigger("another-event", new { what = false });
```

Of course this works the same with or without detail being provided for the event, and timing can also be overridden (to push to an alternative header):
```c#
h.WithTrigger("event-name", timing: HtmxTriggerTiming.AfterSettle);
```

Notes:

- The Readme has been updated with this (and also a note about the Antiforgery tag, but feel free to remove that)
- The header builder, if there is a single event with no params, will only output the event name (rather than full JSON) in the spirit to save a few characters. Every little helps!
- There are tests that cover off all scenarios, I think, so let me know if you need to see more

**Major note:**

I built this against .NET 6, rather than 5.0. I appreciate it's a big change (and the Action will need updating) however given that 5 is out of support it's probably worth switching to the LTS. (That's why the action is currently failing)