### PR TITLE
Target net6.0 and ASP.NET Core Framework Reference

### DIFF
--- a/src/Htmx.TagHelpers/Htmx.TagHelpers.csproj
+++ b/src/Htmx.TagHelpers/Htmx.TagHelpers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <OutputType>Library</OutputType>
         <Nullable>enable</Nullable>
         <LangVersion>Latest</LangVersion>

--- a/src/Htmx/Htmx.csproj
+++ b/src/Htmx/Htmx.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>
         <LangVersion>latest</LangVersion>

--- a/src/Htmx/Htmx.csproj
+++ b/src/Htmx/Htmx.csproj
@@ -19,16 +19,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="MinVer" Version="2.5.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="System.Text.Json" Version="6.0.5" />
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="MinVer" Version="2.5.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="System.Text.Json" Version="6.0.5" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Target `net6.0`

There is no ASP.NET Core for `netstandard2.0` and `netcoreapp3.1` is out of support. This is also needed to avoid the missing targeting pack error when we switch to FrameworkReferences, see: https://stackoverflow.com/q/63192415/102351

## Replace deprecated package reference with FrameworkReference 

Fixes #19 - Deprecated ASP.NET Core package references