### PR TITLE
Allow existing triggers to be merged in with new trigger definitions

### DIFF
--- a/test/Htmx.Tests/HtmxHttpResponseExtensionsTests.cs
+++ b/test/Htmx.Tests/HtmxHttpResponseExtensionsTests.cs
@@ -122,24 +122,47 @@ public class HtmxHttpResponseExtensionsTests
     }
 
     [Fact]
-    public void Cant_use_legacy_trigger_and_with_trigger()
+    public void Can_use_existing_trigger_with_trigger()
     {
-        Response.Htmx(h => h.Trigger("cool"));
-        Assert.Throws<Exception>(() => Response.Htmx(h => h.WithTrigger("neat")));
+	    const string expected = @"{""neat"":"""",""cool"":""""}";
+
+	    Response.Htmx(h => h.WithTrigger("cool"));
+	    Response.Htmx(h => h.WithTrigger("neat"));
+
+	    Assert.True(Headers.ContainsKey(Keys.Trigger));
+	    Assert.Equal(expected, Headers[Keys.Trigger]);
     }
-        
+
     [Fact]
-    public void Cant_use_legacy_triggeraftersettle_and_with_trigger()
+    public void Can_use_existing_trigger_with_multiple_triggers_with_detail()
     {
-        Response.Htmx(h => h.TriggerAfterSettle("cool"));
-        Assert.Throws<Exception>(() => Response.Htmx(h => h.WithTrigger("neat", timing: HtmxTriggerTiming.AfterSettle)));
+	    const string expected = @"{""cool"":{""magic"":""something""},""neat"":{""moremagic"":false},""wow"":""""}";
+
+	    Response.Htmx(h => h.WithTrigger("wow"));
+	    Response.Htmx(h =>
+	    {
+		    h.WithTrigger("cool", new { magic = "something" });
+		    h.WithTrigger("neat", new { moremagic = false });
+	    });
+
+	    Assert.True(Headers.ContainsKey(Keys.Trigger));
+	    Assert.Equal(expected, Headers[Keys.Trigger]);
     }
-        
+
     [Fact]
-    public void Cant_use_legacy_triggerafterswap_and_with_trigger()
+    public void Can_use_existing_trigger_with_detail_with_multiple_triggers_with_detail()
     {
-        Response.Htmx(h => h.TriggerAfterSwap("cool"));
-        Assert.Throws<Exception>(() => Response.Htmx(h => h.WithTrigger("neat", timing: HtmxTriggerTiming.AfterSwap)));
+	    const string expected = @"{""cool"":{""magic"":""something""},""neat"":{""moremagic"":false},""wow"":{""display"":true}}";
+
+	    Response.Htmx(h => h.WithTrigger("wow", new { display = true }));
+	    Response.Htmx(h =>
+	    {
+		    h.WithTrigger("cool", new { magic = "something" });
+		    h.WithTrigger("neat", new { moremagic = false });
+	    });
+
+	    Assert.True(Headers.ContainsKey(Keys.Trigger));
+	    Assert.Equal(expected, Headers[Keys.Trigger]);
     }
 
     [Fact]


### PR DESCRIPTION
Right now Htmx.Net doesn't play nice with existing trigger headers.  Any third-party components that may attempt to inject trigger headers will fail as Htmx.Net assumes any existing header is a misuse of the library (possibly due to mixing obsolete legacy trigger methods with newer WithTrigger method).

The solution that this PR proposes is to pre-load any existing matching triggers currently in the outgoing response into the _triggers dictionary when all triggers are processed.  If a newer trigger with the same key as an existing trigger is used the old version will be ignored.  

In order to accommodate this change I had to remove the check to see if the legacy obsolete Trigger* methods were called alongside the WithTrigger method.  The net effect is that calling a Trigger* method prior to calling WithTrigger will cause the Trigger* events be treated as a simple non-detailed events to be merged together with WithTrigger events.

Tests were added to ensure that all triggers would be aggregated across multiple attempts to add triggers.  I had to remove tests that would check for combinations of legacy Trigger* method and WithTrigger since this check would be functionally obsolete because triggers would be merged.

This is backwards compatible with the existing code since the change only takes place if a trigger header already exists before trying to add it. Multiple triggers are combined as detailed events even if the detail payload is empty.