### PR TITLE
Adding hx-headers-* server-side processing to hx-headers

### DIFF
--- a/src/Htmx.TagHelpers/HtmxHeadersTagHelper.cs
+++ b/src/Htmx.TagHelpers/HtmxHeadersTagHelper.cs
@@ -1,0 +1,54 @@
+﻿using JetBrains.Annotations;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using System.Collections.Generic;
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Htmx.TagHelpers
+{
+    /// <summary>
+    /// Targets any element that has hx-get, hx-post, hx-put, hx-patch, and hx-delete.
+    /// https://htmx.org/attributes/hx-headers/
+    /// </summary>
+    [PublicAPI]
+    [HtmlTargetElement("*", Attributes = "[hx-post]")]
+    [HtmlTargetElement("*", Attributes = "[hx-put]")]
+    [HtmlTargetElement("*", Attributes = "[hx-delete]")]
+    [HtmlTargetElement("*", Attributes = "[hx-patch]")]
+    public class HxHeaders : TagHelper
+    {
+        /// <summary>
+        /// JSON formatted string, a Dictionary or any object.
+        /// </summary>
+        [HtmlAttributeName("hx-headers")]
+        public object Headers { get; set; } = default!;
+
+        /// <summary>
+        /// Dictionary of hx-headers's html attributes
+        /// </summary>
+        [HtmlAttributeName("hx-headers", DictionaryAttributePrefix = "hx-headers-")]
+        public IDictionary<string, string?> HeaderAttributes { get; set; } = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            var jsonObject = Headers switch
+            {
+                string headerJson => JsonSerializer.Deserialize<JsonObject>(headerJson),
+                null => null,
+                _ => JsonSerializer.Deserialize<JsonObject>(JsonSerializer.Serialize(Headers))
+            } ?? new JsonObject();
+
+            // merge
+            foreach (var jObject in jsonObject)
+            {
+                HeaderAttributes[jObject.Key] = jObject.Value?.ToString();
+            }
+
+            // serialize
+            var json = JsonSerializer.Serialize(HeaderAttributes);
+
+            output.Attributes.Add("hx-headers", json);
+        }
+    }
+}

--- a/src/Htmx.TagHelpers/HtmxHeadersTagHelper.cs
+++ b/src/Htmx.TagHelpers/HtmxHeadersTagHelper.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Linq;
 
 namespace Htmx.TagHelpers
 {
@@ -19,30 +20,17 @@ namespace Htmx.TagHelpers
     public class HxHeaders : TagHelper
     {
         /// <summary>
-        /// JSON formatted string, a Dictionary or any object.
-        /// </summary>
-        [HtmlAttributeName("hx-headers")]
-        public object Headers { get; set; } = default!;
-
-        /// <summary>
         /// Dictionary of hx-headers's html attributes
         /// </summary>
-        [HtmlAttributeName("hx-headers", DictionaryAttributePrefix = "hx-headers-")]
+        [HtmlAttributeName(DictionaryAttributePrefix = "hx-headers-")]
         public IDictionary<string, string?> HeaderAttributes { get; set; } = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            var jsonObject = Headers switch
+            var existingHeaders = output.Attributes["hx-headers"]?.Value;
+            if (existingHeaders != null || !HeaderAttributes.Any())
             {
-                string headerJson => JsonSerializer.Deserialize<JsonObject>(headerJson),
-                null => null,
-                _ => JsonSerializer.Deserialize<JsonObject>(JsonSerializer.Serialize(Headers))
-            } ?? new JsonObject();
-
-            // merge
-            foreach (var jObject in jsonObject)
-            {
-                HeaderAttributes[jObject.Key] = jObject.Value?.ToString();
+                return;
             }
 
             // serialize

--- a/src/Htmx.TagHelpers/HtmxHeadersTagHelper.cs
+++ b/src/Htmx.TagHelpers/HtmxHeadersTagHelper.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 using System.Collections.Generic;
 using System;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Linq;
 
 namespace Htmx.TagHelpers
@@ -13,22 +12,24 @@ namespace Htmx.TagHelpers
     /// https://htmx.org/attributes/hx-headers/
     /// </summary>
     [PublicAPI]
+    [HtmlTargetElement("*", Attributes = "[hx-get]")]
     [HtmlTargetElement("*", Attributes = "[hx-post]")]
     [HtmlTargetElement("*", Attributes = "[hx-put]")]
     [HtmlTargetElement("*", Attributes = "[hx-delete]")]
     [HtmlTargetElement("*", Attributes = "[hx-patch]")]
-    public class HxHeaders : TagHelper
+    public class HtmxHeadersTagHelper : TagHelper
     {
         /// <summary>
-        /// Dictionary of hx-headers's html attributes
+        /// Dictionary of hx-headers
         /// </summary>
         [HtmlAttributeName(DictionaryAttributePrefix = "hx-headers-")]
         public IDictionary<string, string?> HeaderAttributes { get; set; } = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
+        /// <inheritdoc />
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            var existingHeaders = output.Attributes["hx-headers"]?.Value;
-            if (existingHeaders != null || !HeaderAttributes.Any())
+            var existingHxHeaders = output.Attributes["hx-headers"]?.Value;
+            if (existingHxHeaders != null || !HeaderAttributes.Any())
             {
                 return;
             }

--- a/test/Htmx.Tests/Htmx.Tests.csproj
+++ b/test/Htmx.Tests/Htmx.Tests.csproj
@@ -25,6 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\src\Htmx.TagHelpers\Htmx.TagHelpers.csproj" />
       <ProjectReference Include="..\..\src\Htmx\Htmx.csproj" />
     </ItemGroup>
 

--- a/test/Htmx.Tests/TagHelpers/HtmxHeadersTagHelperTests.cs
+++ b/test/Htmx.Tests/TagHelpers/HtmxHeadersTagHelperTests.cs
@@ -1,0 +1,92 @@
+﻿using Htmx.TagHelpers;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Htmx.Tests.TagHelpers
+{
+    public class HtmxHeadersTagHelperTests
+    {
+        private readonly HtmxHeadersTagHelper _tagHelper;
+        private readonly TagHelperContext _context;
+        private readonly TagHelperOutput _output;
+
+        public HtmxHeadersTagHelperTests()
+        {
+            _tagHelper = new HtmxHeadersTagHelper();
+
+            _context = new TagHelperContext(
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                "test_unique_id");
+
+            _output = new TagHelperOutput(
+                "div",
+                new TagHelperAttributeList(),
+                (useCachedResult, encoder) =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    var tagBuilder = new TagBuilder("div");
+                    tagBuilder.Attributes.Add("hx-post", "url");
+                    tagHelperContent.SetHtmlContent(tagBuilder);
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
+        }
+
+        [Fact]
+        public void Is_HeaderAttributes_NotNull()
+        {
+            Assert.NotNull(_tagHelper.HeaderAttributes);
+            Assert.Empty(_tagHelper.HeaderAttributes);
+        }
+
+        [Fact]
+        public void Process_AddsHeadersAttribute_WhenNoExistingHeadersAndHeaderAttributesPresent()
+        {
+            // Arrange
+            _tagHelper.HeaderAttributes.Add("Key1", "Value1");
+            _tagHelper.HeaderAttributes.Add("Key2", "Value2");
+
+            // Act
+            _tagHelper.Process(_context, _output);
+
+            // Assert
+            Assert.True(_output.Attributes.TryGetAttribute("hx-headers", out var headersAttribute));
+            Assert.NotNull(headersAttribute);
+
+            var json = JsonSerializer.Deserialize<JsonObject>(headersAttribute.Value.ToString()!)!;
+            Assert.Equal("Value1", json["Key1"]!.GetValue<string>());
+            Assert.Equal("Value2", json["Key2"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public void Process_DoesNotAddHeadersAttribute_WhenExistingHeadersPresent()
+        {
+            // Arrange
+            var existingHeaders = new TagHelperAttribute("hx-headers", "{\"ExistingKey1\":\"ExistingValue1\"}");
+            _output.Attributes.Add(existingHeaders);
+
+            // Act
+            _tagHelper.Process(_context, _output);
+
+            // Assert
+            var json = JsonSerializer.Deserialize<JsonObject>(_output.Attributes["hx-headers"].Value.ToString()!)!;
+            Assert.Equal("ExistingValue1", json["ExistingKey1"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public void Process_DoesNotAddHeadersAttribute_WhenNoHeaderAttributes()
+        {
+            // Act
+            _tagHelper.Process(_context, _output);
+
+            // Assert
+            Assert.False(_output.Attributes.TryGetAttribute("hx-headers", out _));
+        }
+    }
+
+}

--- a/test/Sample/Pages/Headers.cshtml
+++ b/test/Sample/Pages/Headers.cshtml
@@ -7,9 +7,8 @@
     <button type="button"
             hx-post
             hx-page="./Headers"
-            hx-headers-Button="2"
-            hx-headers-Key1="value1"
-            hx-headers-Key2="value2"
+            hx-headers-New-Key1="NewValue1"
+            hx-headers-New-Key2="NewValue2"
             hx-swap="innerHTML"
             hx-target="#post-result">
         Click me (using hx-headers-key="value")
@@ -20,9 +19,9 @@
     <button type="button"
             hx-post
             hx-page="./Headers"
-            hx-headers='{ "Key1": "ExistingValue1", "Key2": "ExistingValue1" }'
-            hx-headers-Key1="NewValue1"
-            hx-headers-Key2="NewValue2"
+            hx-headers='{ "Existing-Key1": "ExistingValue1", "Existing-Key2": "ExistingValue1" }'
+            hx-headers-New-Key1="NewValue1"
+            hx-headers-New-Key2="NewValue2"
             hx-swap="innerHTML"
             hx-target="#post-result">
         Click me (with existing hx-headers)

--- a/test/Sample/Pages/Headers.cshtml
+++ b/test/Sample/Pages/Headers.cshtml
@@ -7,17 +7,6 @@
     <button type="button"
             hx-post
             hx-page="./Headers"
-            hx-headers="@(new { button = 1, key1 = "value1", key2 = "value2" })"
-            hx-swap="innerHTML"
-            hx-target="#post-result">
-        Click me (using hx-headers=new object())
-    </button>
-</div>
-
-<div>
-    <button type="button"
-            hx-post
-            hx-page="./Headers"
             hx-headers-Button="2"
             hx-headers-Key1="value1"
             hx-headers-Key2="value2"
@@ -31,12 +20,12 @@
     <button type="button"
             hx-post
             hx-page="./Headers"
-            hx-headers="@(new { button = 3, key1 = "value1", key2 = "value2" })"
-            hx-headers-Key3="value3"
-            hx-headers-Key4="value4"
+            hx-headers='{ "Key1": "ExistingValue1", "Key2": "ExistingValue1" }'
+            hx-headers-Key1="NewValue1"
+            hx-headers-Key2="NewValue2"
             hx-swap="innerHTML"
             hx-target="#post-result">
-        Click me (using hx-headers and hx-headers-key="value")
+        Click me (with existing hx-headers)
     </button>
 </div>
 

--- a/test/Sample/Pages/Headers.cshtml
+++ b/test/Sample/Pages/Headers.cshtml
@@ -28,6 +28,23 @@
     </button>
 </div>
 
+<div>
+    Testing: https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
+    <br/>
+    <button type="button"
+            hx-post
+            hx-page="./Headers"
+            hx-headers-X-Forwarded-Host="en.wikipedia.org:8080"
+            hx-headers-X-Front-End-Https="on"
+            hx-headers-X-Forwarded-For="client1, proxy1, proxy2"
+            hx-headers-Upgrade-Insecure-Requests="1"
+            hx-headers-X-LongCustom-Header="Stuff"
+            hx-swap="innerHTML"
+            hx-target="#post-result">
+        Click me (List_of_HTTP_header_fields)
+    </button>
+</div>
+
 <div class="mt-2">
     <code>requestConfig.headers</code>
     <textarea class="w-100" id="post-result" rows="10"></textarea>

--- a/test/Sample/Pages/Headers.cshtml
+++ b/test/Sample/Pages/Headers.cshtml
@@ -1,0 +1,58 @@
+﻿@page
+@using Microsoft.AspNetCore.Antiforgery;
+@inject IAntiforgery antiforgery;
+@model HxRequestsModel
+
+<div>
+    <button type="button"
+            hx-post
+            hx-page="./Headers"
+            hx-headers="@(new { button = 1, key1 = "value1", key2 = "value2" })"
+            hx-swap="innerHTML"
+            hx-target="#post-result">
+        Click me (using hx-headers=new object())
+    </button>
+</div>
+
+<div>
+    <button type="button"
+            hx-post
+            hx-page="./Headers"
+            hx-headers-Button="2"
+            hx-headers-Key1="value1"
+            hx-headers-Key2="value2"
+            hx-swap="innerHTML"
+            hx-target="#post-result">
+        Click me (using hx-headers-key="value")
+    </button>
+</div>
+
+<div>
+    <button type="button"
+            hx-post
+            hx-page="./Headers"
+            hx-headers="@(new { button = 3, key1 = "value1", key2 = "value2" })"
+            hx-headers-Key3="value3"
+            hx-headers-Key4="value4"
+            hx-swap="innerHTML"
+            hx-target="#post-result">
+        Click me (using hx-headers and hx-headers-key="value")
+    </button>
+</div>
+
+<div class="mt-2">
+    <code>requestConfig.headers</code>
+    <textarea class="w-100" id="post-result" rows="10"></textarea>
+</div>
+
+@section Scripts {
+    <script type="text/javascript">
+        window.addEventListener("htmx:afterRequest", evt => {
+            let headers = evt.detail.requestConfig.headers;
+            let json = JSON.stringify(headers, null, 2);
+
+            document.querySelector('#post-result').innerHTML = json;
+        });
+    </script>
+}
+

--- a/test/Sample/Pages/Headers.cshtml.cs
+++ b/test/Sample/Pages/Headers.cshtml.cs
@@ -1,0 +1,20 @@
+using Htmx;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Text.Json;
+
+namespace Sample.Pages
+{
+    [ValidateAntiForgeryToken]
+    public class HxRequestsModel : PageModel
+    {
+        public IActionResult OnPost()
+        {
+            // list of headers
+            var headers = Request.Headers.ToList();
+            var html = "<pre>" + JsonSerializer.Serialize(headers, new JsonSerializerOptions { WriteIndented = true }) + "</pre>";
+
+            return Content(html, "text/html");
+        }
+    }
+}

--- a/test/Sample/Pages/Shared/_Layout.cshtml
+++ b/test/Sample/Pages/Shared/_Layout.cshtml
@@ -38,6 +38,9 @@
                         <a class="nav-link text-dark" asp-area="" asp-page="/Response">Response.Htmx()</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link text-dark" asp-area="" asp-page="/Headers"><code>hx-headers</code></a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
                     </li>
                 </ul>


### PR DESCRIPTION
Hi @khalidabuhakmeh ,  

I'm suggesting the addition of `hx-headers-*` support to Htmx.Net, which will enable developers to set custom HTTP headers for htmx requests. This enhancement aligns with the documentation [https://htmx.org/attributes/hx-headers](https://htmx.org/attributes/hx-headers).

With this feature, you can now define headers like this:

```
<button type="button"
        hx-post
        hx-page="./Headers"
        hx-headers-Key1="value1"
        hx-headers-Key2="value2"
        hx-swap="innerHTML"
        hx-target="#post-result">Click Me</button>
```
or
```
<button type="button"
        hx-post
        hx-page="./Headers"
        hx-headers="new { Key1 = "value1", Key2 = "value2" }"
        hx-swap="innerHTML"
        hx-target="#post-result">Click Me</button>
```

This could also be useful to add `RequestVerificationToken`
```
@inject IAntiforgery antiforgery;
...

<button type="button"
        hx-post
        hx-page="./Headers"
        hx-headers-RequestVerificationToken="@antiforgery.GetAndStoreTokens(HttpContext).RequestToken"
        hx-swap="innerHTML"
        hx-target="#post-result">Click Me</button>
...
```

I want to add unit tests but I don't see Htmx.TagHelper.Tests project. Should the unit tests go under Htmx.Tests project?

I'm excited to hear your feedback on this proposal and whether it aligns with the project's objectives. Thank you for considering this improvement. I also have Sample code in the Sample project. Please take a look and let me now what you think.

