### PR TITLE
Fix `HtmxAntiforgeryScriptEndpoints.Path` #37

### DIFF
--- a/src/Htmx.TagHelpers/HtmxAntiforgeryScriptEndpoints.cs
+++ b/src/Htmx.TagHelpers/HtmxAntiforgeryScriptEndpoints.cs
@@ -7,9 +7,10 @@ namespace Htmx.TagHelpers;
 public static class HtmxAntiforgeryScriptEndpoints
 {
     /// <summary>
-    /// The path to the antiforgery script that is used from HTML
+    /// The path to the antiforgery script that is used from HTML.
+    /// Note: Be sure it is rooted path ("starts with '/') or else it can break as paths get more nested.
     /// </summary>
-    public static string Path { get; private set; } = "_htmx/antiforgery.js";
+    public static string Path { get; private set; } = "/_htmx/antiforgery.js";
 
     /// <summary>
     /// Register an endpoint that responds with the HTMX antiforgery script.<br/>

--- a/test/Sample/Pages/Nested/Index.cshtml
+++ b/test/Sample/Pages/Nested/Index.cshtml
@@ -1,0 +1,19 @@
+﻿@page
+@model IndexModel
+@{
+    ViewData["Title"] = "Home page";
+}
+
+<div class="text-center">
+    <h1 class="display-4">Welcome</h1>
+    <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+</div>
+
+<div hx-target="this">
+    <button hx-post
+            hx-page="Index"
+            hx-page-handler="Snippet"
+            hx-swap="outerHtml">
+        Click Me (Razor Page w/ Handler)
+    </button>
+</div>

--- a/test/Sample/Pages/Nested/Index.cshtml.cs
+++ b/test/Sample/Pages/Nested/Index.cshtml.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Sample.Pages.Nested;
+
+public class IndexModel : PageModel
+{
+    public IndexModel(ILogger<IndexModel> logger)
+    {
+    }
+
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPostSnippet()
+    {
+        return Content("<h2>Hello, World!</h2>", "text/html");
+    }
+}


### PR DESCRIPTION
The original path was relative which caused issues as the routing of the site got more nested. This makes sure the original path is rooted at `/`.

#37