### PR TITLE
Add global config security options to meta tag helper

### DIFF
--- a/src/Htmx.TagHelpers/HtmxConfigMetaTagHelper.cs
+++ b/src/Htmx.TagHelpers/HtmxConfigMetaTagHelper.cs
@@ -91,6 +91,18 @@ public class HtmxConfigMetaTagHelper : TagHelper
     public string? AddedClass { get; set; }
 
     /// <summary>
+    /// defaults to false
+    /// </summary>
+    [HtmlAttributeName("selfRequestsOnly")]
+    public bool SelfRequestsOnly { get; set; }
+
+    /// <summary>
+    /// defaults to true
+    /// </summary>
+    [HtmlAttributeName("allowScriptTags")]
+    public bool AllowScriptTags { get; set; } = true;
+
+    /// <summary>
     /// defaults to true
     /// </summary>
     [HtmlAttributeName("allowEval")]
@@ -187,6 +199,8 @@ public class HtmxConfigMetaTagHelper : TagHelper
         var config = JsonSerializer.Serialize(new
         {
             AllowEval,
+            SelfRequestsOnly,
+            AllowScriptTags,
             DisableSelector,
             HistoryEnabled,
             IndicatorClass,


### PR DESCRIPTION
Adds 2 [configuration settings](https://htmx.org/docs/#config) related to security to the `<meta>` Tag Helper

- htmx.config.selfRequestsOnly - if set to true, only requests to the same domain as the current document will be allowed

- htmx.config.allowScriptTags - htmx will process <script> tags found in new content it loads. If you wish to disable this behavior you can set this configuration variable to false