### PR TITLE
Fix build warning for CVE-2024-43485 #44

### DIFF
--- a/src/Htmx/Htmx.csproj
+++ b/src/Htmx/Htmx.csproj
@@ -25,7 +25,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.Text.Json" Version="6.0.5" />
+		<PackageReference Include="System.Text.Json" Version="6.0.10" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updates System.Text.Json dependency to version not affected by CVE-2024-43485.
#44 