### PR TITLE
use direct parse

### DIFF
--- a/src/Htmx/HtmxResponseHeaders.cs
+++ b/src/Htmx/HtmxResponseHeaders.cs
@@ -267,11 +267,10 @@ public class HtmxResponseHeaders
         // assume if the string starts with '{' and ends with '}', that it is JSON
         if (header.Any(h => h is ['{', .., '}']))
         {
-            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(header));
             // this might still throw :(
-            var jsonObject = JsonNode.Parse(ref reader)?.AsObject();
+            var jsonObject = JsonNode.Parse(header)!.AsObject();
             // Load any existing triggers
-            foreach (var (key, value) in jsonObject!)
+            foreach (var (key, value) in jsonObject)
                 WithTrigger(key, value, timing);
         }
         else


### PR DESCRIPTION
is there any reason a Utf8JsonReader and GetBytes is being used instead of doing a JsonNode.Parse on the string?