### PR TITLE
remove SourceLink

### DIFF
--- a/src/Htmx.TagHelpers/Htmx.TagHelpers.csproj
+++ b/src/Htmx.TagHelpers/Htmx.TagHelpers.csproj
@@ -16,10 +16,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="MinVer" Version="2.5.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
https://github.com/dotnet/sourcelink/releases

> Source Link is now included in .NET SDK 8 and enabled by default. Projects that migrate to .NET SDK 8 do not need to reference Source Link packages explicitly via PackageReference anymore.